### PR TITLE
Upgrade deprecated runtime nodejs10.x

### DIFF
--- a/sgw/fileshare-refresh-schedule.yaml
+++ b/sgw/fileshare-refresh-schedule.yaml
@@ -71,7 +71,7 @@ Resources:
           FILE_SHARE: !Ref FileGatewayShare
       Handler: index.handler
       Role: !GetAtt LambdaIAMRole.Arn
-      Runtime: nodejs10.x
+      Runtime: nodejs14.x
       Timeout: 5
       Tags: 
         -


### PR DESCRIPTION
CloudFormation templates in aws-cloud-video-editing have been found to include a soon to be [deprecated Lambda function runtime](https://docs.aws.amazon.com/lambda/latest/dg/runtime-support-policy.html) (nodejs10.x). The affected templates have been updated to a supported runtime (nodejs14.x).

Please note, **this pull request has been generated by a bot**; please check the base branch and files changed before merging.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.