### PR TITLE
Add NiceDCV Protocol support for the Edit Workstation

### DIFF
--- a/deployment/templates/aws-edit-in-the-cloud-edit-host.template
+++ b/deployment/templates/aws-edit-in-the-cloud-edit-host.template
@@ -222,8 +222,8 @@ Resources:
             C:\cfn\scripts\install-gpu-drivers.ps1:
               source: !Sub 'https://${CloudFormationBucketName}.s3.${AWS::Region}.${AWS::URLSuffix}/${CloudFormationKeyPrefix}/install-gpu-drivers.ps1'
               authentication: S3AccessCreds
-            C:\cfn\scripts\install-teradici.ps1:
-              source: !Sub 'https://${CloudFormationBucketName}.s3.${AWS::Region}.${AWS::URLSuffix}/${CloudFormationKeyPrefix}/install-teradici.ps1'
+            C:\cfn\scripts\install-nicedcv.ps1:
+              source: !Sub 'https://${CloudFormationBucketName}.s3.${AWS::Region}.${AWS::URLSuffix}/${CloudFormationKeyPrefix}/install-nicedcv.ps1'
               authentication: S3AccessCreds
             C:\ProgramData\Microsoft\Windows\Start Menu\Programs\StartUp\automount.bat:
               content: !Sub |
@@ -249,8 +249,8 @@ Resources:
             '10-reboot':
               command: 'powershell.exe -ExecutionPolicy Unrestricted C:\cfn\scripts\Restart-Computer.ps1'
               waitAfterCompletion: forever
-            '15-install-teradici':
-              command: 'powershell.exe -ExecutionPolicy Unrestricted C:\cfn\scripts\install-teradici.ps1 -Verbose'
+            '15-install-nicedcv':
+              command: 'powershell.exe -ExecutionPolicy Unrestricted C:\cfn\scripts\install-nicedcv.ps1 -Verbose'
               waitAfterCompletion: '0'
         joinDomain:
           commands:

--- a/deployment/templates/aws-edit-in-the-cloud-edit-host.template
+++ b/deployment/templates/aws-edit-in-the-cloud-edit-host.template
@@ -144,6 +144,10 @@ Resources:
                   - s3:GetObject
                 Resource: 'arn:aws:s3:::ec2-windows-nvidia-drivers/*'
                 Effect: Allow
+              - Action:
+                  - s3:GetObject
+                Resource: !Sub 'arn:aws:s3:::dcv-license.${AWS::Region}/*'
+                Effect: Allow
           PolicyName: aws-s3-policy
       Path: /
       AssumeRolePolicyDocument:

--- a/deployment/templates/aws-edit-in-the-cloud-edit-host.template
+++ b/deployment/templates/aws-edit-in-the-cloud-edit-host.template
@@ -91,6 +91,13 @@ Parameters:
     Type: String
     Description: Amazon EC2 instance type for the video editing server
     Default: g4dn.4xlarge
+  RemoteDisplayProtocol:
+    Description: Remote Display Protocol configured on the instance (Teradici PCoIP | NiceDCV)
+    Type: String
+    Default: teradici
+    AllowedValues:
+      - teradici
+      - nicedcv
   Windows2019AmiId:
     Type: 'AWS::SSM::Parameter::Value<AWS::EC2::Image::Id>'
     Default: '/aws/service/ami-windows-latest/Windows_Server-2019-English-Full-Base'
@@ -124,6 +131,11 @@ Parameters:
       S3 key prefix for the CloudFormation assets. The key prefix can include numbers,
       lowercase letters, uppercase letters, hyphens (-), and forward slash (/).
     Type: String
+
+Conditions:
+  DeployTeradici: !Equals [!Ref RemoteDisplayProtocol, teradici]
+  DeployNiceDCV: !Equals [!Ref RemoteDisplayProtocol, nicedcv]
+
 Resources:
   EditHostRole:
     Type: AWS::IAM::Role
@@ -144,10 +156,13 @@ Resources:
                   - s3:GetObject
                 Resource: 'arn:aws:s3:::ec2-windows-nvidia-drivers/*'
                 Effect: Allow
-              - Action:
-                  - s3:GetObject
-                Resource: !Sub 'arn:aws:s3:::dcv-license.${AWS::Region}/*'
-                Effect: Allow
+              - !If
+                - DeployNiceDCV
+                - Action:
+                    - s3:GetObject
+                  Resource: !Sub 'arn:aws:s3:::dcv-license.${AWS::Region}/*'
+                  Effect: Allow
+                - !Ref AWS::NoValue
           PolicyName: aws-s3-policy
       Path: /
       AssumeRolePolicyDocument:
@@ -179,6 +194,14 @@ Resources:
           config:
             - setup
             - configInstance
+            - !If 
+              - DeployNiceDCV
+              - installNiceDCV
+              - !Ref AWS::NoValue
+            - !If 
+              - DeployTeradici
+              - installTeradici
+              - !Ref AWS::NoValue
             - joinDomain
             - finalize
         setup:
@@ -226,9 +249,6 @@ Resources:
             C:\cfn\scripts\install-gpu-drivers.ps1:
               source: !Sub 'https://${CloudFormationBucketName}.s3.${AWS::Region}.${AWS::URLSuffix}/${CloudFormationKeyPrefix}/install-gpu-drivers.ps1'
               authentication: S3AccessCreds
-            C:\cfn\scripts\install-nicedcv.ps1:
-              source: !Sub 'https://${CloudFormationBucketName}.s3.${AWS::Region}.${AWS::URLSuffix}/${CloudFormationKeyPrefix}/install-nicedcv.ps1'
-              authentication: S3AccessCreds
             C:\ProgramData\Microsoft\Windows\Start Menu\Programs\StartUp\automount.bat:
               content: !Sub |
                     @echo OFF
@@ -253,8 +273,23 @@ Resources:
             '10-reboot':
               command: 'powershell.exe -ExecutionPolicy Unrestricted C:\cfn\scripts\Restart-Computer.ps1'
               waitAfterCompletion: forever
-            '15-install-nicedcv':
+        installNiceDCV:
+          files: 
+            C:\cfn\scripts\install-nicedcv.ps1:
+              source: !Sub 'https://${CloudFormationBucketName}.s3.${AWS::Region}.${AWS::URLSuffix}/${CloudFormationKeyPrefix}/install-nicedcv.ps1'
+              authentication: S3AccessCreds
+          commands:
+            '01-install-nicedcv':
               command: 'powershell.exe -ExecutionPolicy Unrestricted C:\cfn\scripts\install-nicedcv.ps1 -Verbose'
+              waitAfterCompletion: '0'
+        installTeradici:
+          files:
+            C:\cfn\scripts\install-teradici.ps1:
+              source: !Sub 'https://${CloudFormationBucketName}.s3.${AWS::Region}.${AWS::URLSuffix}/${CloudFormationKeyPrefix}/install-teradici.ps1'
+              authentication: S3AccessCreds
+          commands:
+            '01-install-teradici':
+              command: 'powershell.exe -ExecutionPolicy Unrestricted C:\cfn\scripts\install-teradici.ps1 -Verbose'
               waitAfterCompletion: '0'
         joinDomain:
           commands:

--- a/deployment/templates/aws-edit-in-the-cloud-fsx-dns-name.template
+++ b/deployment/templates/aws-edit-in-the-cloud-fsx-dns-name.template
@@ -91,6 +91,7 @@ Resources:
       CompatibleRuntimes: 
         - python3.7
         - python3.8
+        - python3.9
       Content: 
         S3Bucket: !Ref CloudFormationBucketName
         S3Key: !Ref Boto3LayerS3Key
@@ -109,7 +110,7 @@ Resources:
     Properties:
       FunctionName: !Sub '${Project}-FSxDNSNameLambda'
       Description: Get FSx DNS Name (file_system_id)
-      Runtime: python3.8
+      Runtime: python3.9
       Code:
         S3Bucket: !Ref CloudFormationBucketName
         S3Key: !Ref LambdaFunctionS3Key

--- a/deployment/templates/aws-edit-in-the-cloud-host-security-group.template
+++ b/deployment/templates/aws-edit-in-the-cloud-host-security-group.template
@@ -52,6 +52,16 @@ Resources:
           FromPort: 4172
           ToPort: 4172
           CidrIp: !Ref 'HostAccessCIDR'
+        - IpProtocol: tcp
+          Description: "NiceDCV"
+          FromPort: 8443
+          ToPort: 8443
+          CidrIp: !Ref 'HostAccessCIDR'
+        - IpProtocol: udp
+          Description: "NiceDCV"
+          FromPort: 8443
+          ToPort: 8443
+          CidrIp: !Ref 'HostAccessCIDR'
       VpcId: !Ref 'VPCID'
 Outputs:
   EditInstanceSG:

--- a/deployment/templates/aws-edit-in-the-cloud-host-security-group.template
+++ b/deployment/templates/aws-edit-in-the-cloud-host-security-group.template
@@ -8,6 +8,18 @@ Parameters:
   VPCID:
     Description: ID of the VPC (e.g., vpc-0343606e)
     Type: AWS::EC2::VPC::Id
+  RemoteDisplayProtocol:
+    Description: Remote Display Protocol configured on the instance (Teradici PCoIP | NiceDCV)
+    Type: String
+    Default: teradici
+    AllowedValues:
+      - teradici
+      - nicedcv
+
+Conditions:
+  DeployTeradici: !Equals [!Ref RemoteDisplayProtocol, teradici]
+  DeployNiceDCV: !Equals [!Ref RemoteDisplayProtocol, nicedcv]
+
 Resources:
   HostSecurityGroup:
     Type: AWS::EC2::SecurityGroup
@@ -42,26 +54,38 @@ Resources:
           FromPort: 443
           ToPort: 443
           CidrIp: !Ref 'HostAccessCIDR'
-        - IpProtocol: udp
-          Description: "Teradici PCoIP"
-          FromPort: 4172
-          ToPort: 4172
-          CidrIp: !Ref 'HostAccessCIDR'
-        - IpProtocol: tcp
-          Description: "Teradici PCoIP"
-          FromPort: 4172
-          ToPort: 4172
-          CidrIp: !Ref 'HostAccessCIDR'
-        - IpProtocol: tcp
-          Description: "NiceDCV"
-          FromPort: 8443
-          ToPort: 8443
-          CidrIp: !Ref 'HostAccessCIDR'
-        - IpProtocol: udp
-          Description: "NiceDCV"
-          FromPort: 8443
-          ToPort: 8443
-          CidrIp: !Ref 'HostAccessCIDR'
+        - !If 
+          - DeployTeradici
+          - IpProtocol: udp
+            Description: "Teradici PCoIP"
+            FromPort: 4172
+            ToPort: 4172
+            CidrIp: !Ref 'HostAccessCIDR'
+          - !Ref AWS::NoValue
+        - !If 
+          - DeployTeradici
+          - IpProtocol: tcp
+            Description: "Teradici PCoIP"
+            FromPort: 4172
+            ToPort: 4172
+            CidrIp: !Ref 'HostAccessCIDR'
+          - !Ref AWS::NoValue
+        - !If 
+          - DeployNiceDCV
+          - IpProtocol: tcp
+            Description: "NiceDCV"
+            FromPort: 8443
+            ToPort: 8443
+            CidrIp: !Ref 'HostAccessCIDR'
+          - !Ref AWS::NoValue
+        - !If 
+          - DeployNiceDCV
+          - IpProtocol: udp
+            Description: "NiceDCV"
+            FromPort: 8443
+            ToPort: 8443
+            CidrIp: !Ref 'HostAccessCIDR'
+          - !Ref AWS::NoValue
       VpcId: !Ref 'VPCID'
 Outputs:
   EditInstanceSG:

--- a/deployment/templates/aws-edit-in-the-cloud-host-security-group.template
+++ b/deployment/templates/aws-edit-in-the-cloud-host-security-group.template
@@ -49,11 +49,14 @@ Resources:
           FromPort: 3389
           ToPort: 3389
           CidrIp: !Ref 'HostAccessCIDR'
-        - IpProtocol: tcp
-          Description: "HTTPS"
-          FromPort: 443
-          ToPort: 443
-          CidrIp: !Ref 'HostAccessCIDR'
+        - !If 
+          - DeployTeradici
+          - IpProtocol: tcp
+            Description: "HTTPS"
+            FromPort: 443
+            ToPort: 443
+            CidrIp: !Ref 'HostAccessCIDR'
+          - !Ref AWS::NoValue
         - !If 
           - DeployTeradici
           - IpProtocol: udp

--- a/deployment/templates/aws-edit-in-the-cloud.template
+++ b/deployment/templates/aws-edit-in-the-cloud.template
@@ -69,6 +69,8 @@ Metadata:
         default: Edit Host Access CIDR
       KeyPairName:
         default: Key Pair Name
+      RemoteDisplayProtocol:
+        default: Remote Display Protocol
       EditHostInstanceType:
         default: Amazon EC2 instance type for the video editing server
       PrivateSubnet1CIDR:

--- a/deployment/templates/aws-edit-in-the-cloud.template
+++ b/deployment/templates/aws-edit-in-the-cloud.template
@@ -48,7 +48,6 @@ Metadata:
           - DomainNetBIOSName
           - DomainAdminUser
           - DomainAdminPassword
-          - ADEdition
       - Label:
           default: FSX Configuration
         Parameters:
@@ -60,8 +59,6 @@ Metadata:
         default: Availability Zones
       DomainAdminUser:
         default: Domain Admin User
-      ADEdition:
-        default: Standard or Enterprise
       DomainAdminPassword:
         default: Domain Admin Password
       DomainDNSName:
@@ -96,11 +93,6 @@ Parameters:
     Description: >-
       Select 2 Availability Zones to use for the VPC subnets.
     Type: List<AWS::EC2::AvailabilityZone::Name>
-  ADEdition:
-    Default: Standard
-    Description: >-
-      Active Directory edition to deploy.
-    Type: String
   DomainAdminUser:
     AllowedPattern: '[a-zA-Z0-9]*'
     Default: Admin

--- a/deployment/templates/aws-edit-in-the-cloud.template
+++ b/deployment/templates/aws-edit-in-the-cloud.template
@@ -40,6 +40,7 @@ Metadata:
           - EditHostInstanceType
           - EditHostAccessCIDR
           - KeyPairName
+          - RemoteDisplayProtocol
       - Label:
           default: Microsoft Active Directory Configuration
         Parameters:
@@ -154,6 +155,13 @@ Parameters:
       Public/private key pairs allow you to securely connect to your instance
       after it launches
     Type: AWS::EC2::KeyPair::KeyName
+  RemoteDisplayProtocol:
+    Description: Remote Display Protocol configured on the instance (Teradici PCoIP | NiceDCV)
+    Type: String
+    Default: teradici
+    AllowedValues:
+      - teradici
+      - nicedcv
   PrivateSubnet1CIDR:
     AllowedPattern: ^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])(\/(1[6-9]|2[0-8]))$
     ConstraintDescription: CIDR block parameter must be in the form x.x.x.x/16-28
@@ -254,6 +262,7 @@ Resources:
       Parameters:
         HostAccessCIDR: !Ref 'EditHostAccessCIDR'
         VPCID: !GetAtt 'VPCStack.Outputs.VPCID'
+        RemoteDisplayProtocol: !Ref 'RemoteDisplayProtocol'
   ADStack:
     DependsOn: HostSecGrpStack
     Type: AWS::CloudFormation::Stack
@@ -295,6 +304,7 @@ Resources:
         DomainNetBIOSName: !Ref 'DomainNetBIOSName'
         InstanceType: !Ref 'EditHostInstanceType'
         KeyPairName: !Ref 'KeyPairName'
+        RemoteDisplayProtocol: !Ref 'RemoteDisplayProtocol'
         HostSubnetId: !GetAtt 'VPCStack.Outputs.PublicSubnet1ID'
         FSxNetworkFileShare: !GetAtt 'FSXDNSNameStack.Outputs.FSxNetworkShare'
         SGWNetworkFileShare: 'NONE'

--- a/source/install-nicedcv.ps1
+++ b/source/install-nicedcv.ps1
@@ -42,7 +42,7 @@ try {
        Write-Host "Start install of NiceDCV ..."
        # '/NoPostReboot' - to prevent reboot
        #
-       Start-Process msiexec.exe -ArgumentList "/I $Destination", '/quiet','/norestart', '/l*v dcv_install_msi.log'  -Wait
+       Start-Process msiexec.exe -ArgumentList "/I $Destination", 'AUTOMATIC_SESSION_OWNER=Administrator', '/quiet','/norestart', '/l*v dcv_install_msi.log'  -Wait
     } else {
         throw "Problem installing NiceDCV, not .msi extension"
     }

--- a/source/install-nicedcv.ps1
+++ b/source/install-nicedcv.ps1
@@ -38,6 +38,11 @@ try {
         }
     }
 
+    # Add a registry key to enable the QUIC (UDP) protocol in NiceDCV
+    New-PSDrive -PSProvider Registry -Name HKU -Root HKEY_USERS
+    New-Item -Path HKU:\S-1-5-18\Software\GSettings\com\nicesoftware\dcv\ -Name connectivity -Force
+    New-ItemProperty -Path HKU:\S-1-5-18\Software\GSettings\com\nicesoftware\dcv\connectivity\ -Name enable-quic-frontend -Value 1
+
     if ([System.IO.Path]::GetExtension($Destination) -eq '.msi') {
        Write-Host "Start install of NiceDCV ..."
        # AUTOMATIC_SESSION_OWNER variable changes the default owner from SYSTEM to the local administrator

--- a/source/install-nicedcv.ps1
+++ b/source/install-nicedcv.ps1
@@ -4,9 +4,9 @@
 [CmdletBinding()]
 param(
     [Parameter(Mandatory=$false)]
-    [string]$Source = 'https://d1uj6qtbmh3dt5.cloudfront.net/2021.2/Servers/nice-dcv-server-x64-Release-2021.2-11135.msi',
+    [string]$Source = 'https://d1uj6qtbmh3dt5.cloudfront.net/nice-dcv-server-x64-Release.msi',
     [Parameter(Mandatory=$false)]
-    [string]$Destination = 'C:\cfn\downloads\nice-dcv-server-x64-Release-2021.2-11135.msi'
+    [string]$Destination = 'C:\cfn\downloads\nice-dcv-server-x64-Release.msi'
 )
 
 try {
@@ -40,8 +40,9 @@ try {
 
     if ([System.IO.Path]::GetExtension($Destination) -eq '.msi') {
        Write-Host "Start install of NiceDCV ..."
-       # '/NoPostReboot' - to prevent reboot
-       #
+       # AUTOMATIC_SESSION_OWNER variable changes the default owner from SYSTEM to the local administrator
+       # '/norestart' - to prevent reboot
+       # 
        Start-Process msiexec.exe -ArgumentList "/I $Destination", 'AUTOMATIC_SESSION_OWNER=Administrator', '/quiet','/norestart', '/l*v dcv_install_msi.log'  -Wait
     } else {
         throw "Problem installing NiceDCV, not .msi extension"

--- a/source/install-nicedcv.ps1
+++ b/source/install-nicedcv.ps1
@@ -1,0 +1,54 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory=$false)]
+    [string]$Source = 'https://d1uj6qtbmh3dt5.cloudfront.net/2021.2/Servers/nice-dcv-server-x64-Release-2021.2-11135.msi',
+    [Parameter(Mandatory=$false)]
+    [string]$Destination = 'C:\cfn\downloads\nice-dcv-server-x64-Release-2021.2-11135.msi'
+)
+
+try {
+    $ErrorActionPreference = "Stop"
+
+    $parentDir = Split-Path $Destination -Parent
+    if (-not (Test-Path $parentDir)) {
+        New-Item -Path $parentDir -ItemType directory -Force | Out-Null
+    }
+
+    Write-Host "Trying to download NiceDCV from $Source to $Destination"
+    $tries = 5
+    while ($tries -ge 1) {
+        try {
+            (New-Object System.Net.WebClient).DownloadFile($Source,$Destination)
+            break
+        }
+        catch {
+            $tries--
+            Write-Host "Exception:"
+            Write-Host "$_"
+            if ($tries -lt 1) {
+                throw $_
+            }
+            else {
+                Write-Host "Failed download. Retrying again in 5 seconds"
+                Start-Sleep 5
+            }
+        }
+    }
+
+    if ([System.IO.Path]::GetExtension($Destination) -eq '.msi') {
+       Write-Host "Start install of NiceDCV ..."
+       # '/NoPostReboot' - to prevent reboot
+       #
+       Start-Process msiexec.exe -ArgumentList "/I $Destination", '/quiet','/norestart', '/l*v dcv_install_msi.log'  -Wait
+    } else {
+        throw "Problem installing NiceDCV, not .msi extension"
+    }
+    Write-Host "Install NiceDCV complete"
+}
+catch {
+    Write-Host "catch: $_"
+    $_ | Write-AWSQuickStartException
+}


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* This pull request adds a new deployment parameter which allows users to select either Teradici PCoIP or NiceDCV as the protocol used to access the deployed Edit Workstation. 

The change modifies the following elements of the solution:

- New parameter in the top level CFN template to select either Teradici PCoIP or NiceDCV. This is then expressed as condition elements in the host and security group child templates. 
- Security Group rules for NiceDCV (tcp/udp/8443) are opened in the security group template if NiceDCV is selected. Teradici ports are only opened if Teradici is selected. 
- A new boot script is added to download and configure the latest version of the NiceDCV server
- Host cfn:init script now has configuration steps which are activated to install either teradici pcoip or nicedcv
- If NiceDCV is selected, the IAM Role attached to the host also adds permission to access the NiceDCV S3 licensing bucket for licensing purposes. 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
