### PR TITLE
Update nvidia-smi features directory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,10 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [2.3.1] - 2022-11-18
-### Fixed 
-- Update Nvidia Driver installer for Cloud Editing hosts script updated to pull GPU drivers from us-east-1 bucket location. This fixes regions outside of us-east-1 that were unable to install drivers for hosts provisioned outside of us-east-1
+## [2.3.2] - 2022-04-20
 
+- Update the latest GRID /NVIDIA driver location to C:\Windows\System32\DriverStore\FileRepository\nvgrid*\ instead of  C:\Program Files\NVIDIA Corporation\NVSMI
+
+## [2.3.1] - 2022-11-03
+
+- Added -region us-east-1 argument to s3 download cmd for GPU Drivers
 
 ## [2.3.0] - 2022-06-09
 

--- a/source/install-gpu-drivers.ps1
+++ b/source/install-gpu-drivers.ps1
@@ -115,7 +115,7 @@ function InstallGpuDrivers($SetupDir) {
 # https://docs.aws.amazon.com/AWSEC2/latest/WindowsGuide/optimize_gpu.html
 function OptimizeGpu() {
     # this is for G4 only
-    Set-Location "C:\Program Files\NVIDIA Corporation\NVSMI"
+    Set-Location "C:\Windows\System32\DriverStore\FileRepository\nvgrid*\"
     .\nvidia-smi --auto-boost-default=0
     .\nvidia-smi -ac "5001,1590"
 }


### PR DESCRIPTION
Background
==========
A change was introduced in the latest version of the NVIDIA Grid Drivers which breaks the install-gpu-drivers.ps1 script. Lines 113-121 in the script fail because the nvidia-smi features directory has changed with the latest driver versions. When installing the latest GRID /NVIDIA driver, the  nvidia-smi.exe is in the C:\Windows\System32\DriverStore\FileRepository\nvgrid*\ instead of  C:\Program Files\NVIDIA Corporation\NVSMI

Changes
=======
- Update the latest GRID /NVIDIA driver location to C:\Windows\System32\DriverStore\FileRepository\nvgrid*\ instead of  C:\Program Files\NVIDIA Corporation\NVSMI
- update nodejs and python version from buildspec.yml

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
